### PR TITLE
upgrade librosa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The algorithm for achieving high-fidelity lip-syncing with Wav2Lip and Real-ESRG
 
 ## Testing Model
 
+The repository works with `Python 3.10`.
+
 To test the "Wav2Lip-HD" model, follow these steps:
 
 1. Clone this repository and install requirements using following command (Make sure, Python and CUDA are already installed):

--- a/audio.py
+++ b/audio.py
@@ -97,7 +97,7 @@ def _linear_to_mel(spectogram):
 
 def _build_mel_basis():
     assert hp.fmax <= hp.sample_rate // 2
-    return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels,
+    return librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels,
                                fmin=hp.fmin, fmax=hp.fmax)
 
 def _amp_to_db(x):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 addict
 future
-librosa==0.7.0
+librosa
 lmdb
-numba==0.48
+numba
 numpy
 opencv-contrib-python>=4.2.0.34
 opencv-python


### PR DESCRIPTION
The repository was not working correctly for me due to old versions of `librosa` and `numba`, so I tried to upgrade them.

A small fix in the `audio.py` was enough to make it compatible with python 3.10 and with the latest versions of `librosa==0.10.2.post1` and `numba==0.60.0`.

I tested the repo by running the `inference.py` file.